### PR TITLE
Updated opbnbscan URLs for mainnet/testnet

### DIFF
--- a/docs/build-on-opbnb/opbnb-network-info.md
+++ b/docs/build-on-opbnb/opbnb-network-info.md
@@ -20,7 +20,7 @@ This is a living document and is susceptible to changes.
 | RPC Endpoint    | [See here](#opbnb-rpc-endpoints)                             |
 | Chain ID        | 5611(Testnet), 204(Mainnet)                                  |
 | Currency Symbol | tBNB(Testnet) BNB(Mainnet)                                   |
-| Block Explorer  | https://mainnet.opbnbscan.com, https://opbnbscan.com, https://bscscan.com                  |
+| Block Explorer  | https://testnet.opbnbscan.com, https://opbnbscan.com, https://bscscan.com                  |
 | Bridge          | https://opbnb-testnet-bridge.bnbchain.org, https://opbnb-bridge.bnbchain.org |
 
 

--- a/docs/build-on-opbnb/wallet-configuration.md
+++ b/docs/build-on-opbnb/wallet-configuration.md
@@ -43,7 +43,7 @@ To configure your wallet to work with opBNB, you will need to add both the BNB s
    - RPC URL: [https://opbnb-testnet-rpc.bnbchain.org](https://opbnb-testnet-rpc.bnbchain.org)
    - ChainID: 5611
    - Symbol: tBNB
-   - Explorer: [http://opbnbscan.com/](http://opbnbscan.com/)
+   - Explorer: [http://testnet.opbnbscan.com/](http://testnet.opbnbscan.com/)
 
    #### Mainnet
 
@@ -51,7 +51,7 @@ To configure your wallet to work with opBNB, you will need to add both the BNB s
    - RPC URL: [https://opbnb-mainnet-rpc.bnbchain.org ](https://opbnb-mainnet-rpc.bnbchain.org)
    - ChainID: 204
    - Symbol: BNB
-   - Explorer: [http://mainnet.opbnbscan.com/](http://mainnet.opbnbscan.com/)
+   - Explorer: [http://opbnbscan.com/](http://opbnbscan.com/)
 
 ## References - How to configure Trustwallet or Metamask
 


### PR DESCRIPTION
Updated network and wallet configuration to show the changes for opbnbscan.com URLs after mainnet went live.