### PR TITLE
Adding Safe Transaction Service API to Multi-sig Wallet Page

### DIFF
--- a/docs/build-on-opbnb/multisig-wallet.md
+++ b/docs/build-on-opbnb/multisig-wallet.md
@@ -15,4 +15,13 @@ BNB Chain deployed a multi-sig wallet service based on the Gnosis Safe protocol 
 
 To use the BNB Chain multi-sig wallet service, connect with your own EOA wallet to start. Visit [https://multisig.bnbchain.org/welcome](https://multisig.bnbchain.org/welcome)
 
-Read the [Safe Doc](https://docs.safe.global/getting-started/readme) for details.
+Read the [Safe Doc](https://docs.safe.global/getting-started/readme) for details.  
+
+# Safe Transaction Service API
+To create or list safe transactions programmatically, use the Safe Transaction Service API. Here are the endpoints for the opBNB testnet and opBNB mainnet:
+
+Testnet: [https://safe-transaction-opbnb-testnet.bnbchain.org/](https://safe-transaction-opbnb-testnet.bnbchain.org/)
+
+Mainnet: [https://safe-transaction-opbnb-mainnet.bnbchain.org/](https://safe-transaction-opbnb-mainnet.bnbchain.org/)
+
+Read the [api-kit Doc](https://docs.safe.global/safe-core-aa-sdk/api-kit/reference) for details

--- a/docs/build-on-opbnb/multisig-wallet.md
+++ b/docs/build-on-opbnb/multisig-wallet.md
@@ -24,4 +24,4 @@ Testnet: [https://safe-transaction-opbnb-testnet.bnbchain.org/](https://safe-tra
 
 Mainnet: [https://safe-transaction-opbnb-mainnet.bnbchain.org/](https://safe-transaction-opbnb-mainnet.bnbchain.org/)
 
-Read the [api-kit Doc](https://docs.safe.global/safe-core-aa-sdk/api-kit/reference) for details
+Read the [api-kit Doc](https://docs.safe.global/safe-core-aa-sdk/api-kit/reference) for details.


### PR DESCRIPTION
There are users inquiring about the endpoints for Safe Transaction Service API. We should provide them in the documentation so they can access the multi-signature wallet programmatically. Please refer to https://github.com/bnb-chain/opbnb-docs/issues/90